### PR TITLE
Option to adapatively vary pixelated source extent

### DIFF
--- a/herculens/Analysis/plot.py
+++ b/herculens/Analysis/plot.py
@@ -137,7 +137,7 @@ class Plotter(object):
             if lens_image.SourceModel.has_pixels:
                 src_idx = lens_image.SourceModel.pixelated_index
                 source_model = kwargs_source[src_idx]['pixels']
-                src_extent = lens_image.SourceModel.pixel_grid.extent
+                _, _, src_extent = lens_image.get_source_coordinates(kwargs_result['kwargs_lens'])
             elif kwargs_grid_source is not None:
                 grid_src = lens_image.Grid.create_model_grid(**kwargs_grid_source)
                 x_grid_src, y_grid_src = grid_src.pixel_coordinates

--- a/herculens/LensImage/lens_image.py
+++ b/herculens/LensImage/lens_image.py
@@ -1,6 +1,6 @@
 # Defines the model of a strong lens
 # 
-# Copyright (c) 2021, herculens developers and contributors
+# Copyright (c) 2023, herculens developers and contributors
 # Copyright (c) 2018, Simon Birrer & lenstronomy contributors
 # based on the ImSim module from lenstronomy (version 1.9.3)
 
@@ -24,7 +24,7 @@ class LensImage(object):
     def __init__(self, grid_class, psf_class, 
                  noise_class=None, lens_mass_model_class=None,
                  source_model_class=None, lens_light_model_class=None,
-                 kwargs_numerics=None):
+                 source_arc_mask=None, kwargs_numerics=None):
         """
         :param grid_class: coordinate system, instance of PixelGrid() from herculens.Coordinates.pixel_grid
         :param psf_class: point spread function, instance of PSF() from herculens.Instrument.psf
@@ -33,6 +33,7 @@ class LensImage(object):
         :param source_model_class: source light model, instance of LightModel() from herculens.MassModel.mass_model
         :param lens_light_model_class: lens light model, instance of LightModel() from herculens.MassModel.mass_model
         :param kwargs_numerics: keyword arguments for various numerical settings (see herculens.Numerics.numerics)
+        :param source_arc_mask: 2D boolean array to define the region over which the (pixelated) lensed source is modeled
         :param recompute_model_grids: if True, recomputes all coordinate grids for pixelated model components
         """
         self.Grid = grid_class
@@ -64,12 +65,19 @@ class LensImage(object):
             pixel_grid = self.Grid.create_model_grid(**self.LensLightModel.pixel_grid_settings)
             self.LensLightModel.set_pixel_grid(pixel_grid, self.Grid.pixel_area)
 
+        if source_arc_mask is None:
+            source_arc_mask = np.ones(self.Grid.num_pixel_axes)
+        self.source_arc_mask = source_arc_mask
+        self._src_arc_mask_bool = source_arc_mask.astype(bool)
+        self._src_adaptive_grid = self.SourceModel.pixel_is_adaptive
+
         if kwargs_numerics is None:
             kwargs_numerics = {}
         self.ImageNumerics = Numerics(pixel_grid=self.Grid, psf=self.PSF, **kwargs_numerics)
         
     def source_surface_brightness(self, kwargs_source, kwargs_lens=None,
-                                  unconvolved=False, supersampled=False, de_lensed=False, k=None, k_lens=None):
+                                  unconvolved=False, supersampled=False, de_lensed=False, 
+                                  k=None, k_lens=None):
         """
 
         computes the source surface brightness distribution
@@ -84,13 +92,19 @@ class LensImage(object):
         :return: 2d array of surface brightness pixels
         """
         if len(self.SourceModel.profile_type_list) == 0:
-            return jnp.zeros((self.Grid.num_pixel_axes))
-        ra_grid_img, dec_grid_img = self.ImageNumerics.coordinates_evaluate
-        if de_lensed is True:
-            source_light = self.SourceModel.surface_brightness(ra_grid_img, dec_grid_img, kwargs_source, k=k)
+            return jnp.zeros(self.Grid.num_pixel_axes)
+        x_grid_img, y_grid_img = self.ImageNumerics.coordinates_evaluate
+        if self._src_adaptive_grid:
+            pixels_x_coord, pixels_y_coord, _ = self.adapt_source_coordinates(kwargs_lens, k_lens=k_lens)
         else:
-            ra_grid_src, dec_grid_src = self.MassModel.ray_shooting(ra_grid_img, dec_grid_img, kwargs_lens, k=k_lens)
-            source_light = self.SourceModel.surface_brightness(ra_grid_src, dec_grid_src, kwargs_source, k=k)
+            pixels_x_coord, pixels_y_coord = None, None  # fall back on fixed, user-defined coordinates
+        if de_lensed is True:
+            source_light = self.SourceModel.surface_brightness(x_grid_img, y_grid_img, kwargs_source, k=k,
+                                                               pixels_x_coord=pixels_x_coord, pixels_y_coord=pixels_y_coord)
+        else:
+            x_grid_src, y_grid_src = self.MassModel.ray_shooting(x_grid_img, y_grid_img, kwargs_lens, k=k_lens)
+            source_light = self.SourceModel.surface_brightness(x_grid_src, y_grid_src, kwargs_source, k=k,
+                                                               pixels_x_coord=pixels_x_coord, pixels_y_coord=pixels_y_coord)
         if not supersampled:
             source_light = self.ImageNumerics.re_size_convolve(source_light, unconvolved=unconvolved)
         return source_light
@@ -105,8 +119,8 @@ class LensImage(object):
         :param k: list of bool or list of int to select which model profiles to include
         :return: 2d array of surface brightness pixels
         """
-        ra_grid_img, dec_grid_img = self.ImageNumerics.coordinates_evaluate
-        lens_light = self.LensLightModel.surface_brightness(ra_grid_img, dec_grid_img, kwargs_lens_light, k=k)
+        x_grid_img, y_grid_img = self.ImageNumerics.coordinates_evaluate
+        lens_light = self.LensLightModel.surface_brightness(x_grid_img, y_grid_img, kwargs_lens_light, k=k)
         if not supersampled:
             lens_light = self.ImageNumerics.re_size_convolve(lens_light, unconvolved=unconvolved)
         return lens_light
@@ -138,9 +152,12 @@ class LensImage(object):
         else:
             model = jnp.zeros((self.ImageNumerics.grid_class.num_grid_points,))
         if source_add is True:
-            model += self.source_surface_brightness(kwargs_source, kwargs_lens, 
-                                                    unconvolved=unconvolved, supersampled=supersampled,
-                                                    k=k_source, k_lens=k_lens)
+            source_model = self.source_surface_brightness(kwargs_source, kwargs_lens, 
+                                                          unconvolved=unconvolved, supersampled=supersampled,
+                                                          k=k_source, k_lens=k_lens) 
+            if self.source_arc_mask is not None:
+                source_model *= self.source_arc_mask
+            model += source_model
         if lens_light_add is True:
             model += self.lens_surface_brightness(kwargs_lens_light, 
                                                   unconvolved=unconvolved, supersampled=supersampled,
@@ -193,17 +210,65 @@ class LensImage(object):
         norm_res, _ = self.normalized_residuals(data, model, mask=mask)
         num_data_points = np.sum(mask)
         return np.sum(norm_res**2) / num_data_points
-
+    
+    def adapt_source_coordinates(self, kwargs_lens, k_lens=None):
+        """Compute new source coordinates based on ray-traced arc-mask"""
+        npix_src, npix_src_y = self.SourceModel.pixel_grid.num_pixel_axes
+        if npix_src_y != npix_src:
+            raise ValueError("Adaptive source plane grid only works with square grids")
+        if self.Grid.x_is_inverted or self.Grid.y_is_inverted:
+            # TODO: fix this
+            raise NotImplementedError("invert x and y not yet supported for adaptive source grid")
+        # get data coordinates
+        x_grid_img, y_grid_img = self.Grid.pixel_coordinates
+        # ray-shoot to source plane only coordinates within the source arc mask
+        x_grid_src, y_grid_src = self.MassModel.ray_shooting(x_grid_img[self._src_arc_mask_bool], 
+                                                             y_grid_img[self._src_arc_mask_bool], 
+                                                             kwargs_lens, k=k_lens)
+        # create grid encompassed by ray-shooted coordinates
+        x_left, x_right = x_grid_src.min(), x_grid_src.max()
+        y_bottom, y_top = y_grid_src.min(), y_grid_src.max()
+        # center of the region
+        cx = 0.5 * (x_left + x_right)
+        cy = 0.5 * (y_bottom + y_top)
+        # get the width and height
+        width  = jnp.abs(x_left - x_right)
+        height = jnp.abs(y_bottom - y_top)
+        # choose the largest of the two to end up with a square region
+        half_size = jnp.maximum(height, width) / 2.
+        # recompute the new boundaries
+        x_left = cx - half_size
+        x_right = cx + half_size
+        y_bottom = cy - half_size
+        y_top = cy + half_size
+        # print( 0.5*(x_left + x_right), cx )
+        # print( jnp.abs(x_left - x_right), size )
+        # print( 0.5*(y_bottom + y_top), cy )
+        # print( jnp.abs(y_bottom - y_top), size )
+        x_adapt = jnp.linspace(x_left, x_right, npix_src)
+        y_adapt = jnp.linspace(y_bottom, y_top, npix_src)
+        extent_adapt = [x_adapt[0], x_adapt[-1], y_adapt[0], y_adapt[-1]]
+        return x_adapt, y_adapt, extent_adapt
+    
+    def get_source_coordinates(self, kwargs_lens, k_lens=None):
+        if not self._src_adaptive_grid:
+            x_grid, y_grid = self.SourceModel.pixel_grid.pixel_coordinates
+            extent = self.SourceModel.pixel_grid.extent
+        else:
+            x_coord, y_coord, extent = self.adapt_source_coordinates(kwargs_lens, k_lens=k_lens)
+            x_grid, y_grid = np.meshgrid(x_coord, y_coord)
+        return x_grid, y_grid, extent
+        
     def get_lensing_operator(self, kwargs_lens=None, update=False, arc_mask=None):
         if self.SourceModel.pixel_grid is None:
             raise ValueError("The lensing operator is only defined for source "
-                             "models associated to a grid of pixels")
+                            "models associated to a grid of pixels")
         if not hasattr(self, '_lensing_op'):
             self._lensing_op = LensingOperator(self.MassModel,
-                                               self.Grid, # TODO: should be the model grid (from Numerics) at some point
-                                               self.SourceModel.pixel_grid,
-                                               arc_mask=arc_mask)
+                                            self.Grid, # TODO: should be the model grid (from Numerics) at some point
+                                            self.SourceModel.pixel_grid,
+                                            arc_mask=arc_mask)
         if update is True or self._lensing_op.get_lens_mapping() is None:
             self._lensing_op.compute_mapping(kwargs_lens)
         return self._lensing_op
-        
+    

--- a/herculens/LightModel/Profiles/pixelated.py
+++ b/herculens/LightModel/Profiles/pixelated.py
@@ -72,18 +72,33 @@ class Pixelated(object):
     def pixel_grid(self):
         return self._pixel_grid
 
-    def function(self, x, y, pixels):
+    def function(self, x, y, x_pix, y_pix, pixels):
         if self._interp_type == 'fast_bilinear':
-            return self._function_fast(x, y, pixels)
+            return self._function_fast(x, y, x_pix, y_pix, pixels)
         elif self._interp_type in ['bilinear', 'bicubic']:
             return self._function_std(x, y, pixels)
 
-    def _function_fast(self, x, y, pixels):
+    def _function_fast(self, x, y, x_pix, y_pix, pixels):
         """only works when self._interp_type == 'fast_bilinear'"""
         # ensure the coordinates are cartesian by converting angular to pixel units
         x_, y_ = self.pixel_grid.map_coord2pix(x.flatten(), y.flatten())
         x_, y_ = x_.reshape(*x.shape), y_.reshape(*y.shape)
-        f = self._interp_class(self._limits, pixels, cval=0.)(y_, x_)
+        
+        
+        # f = self._interp_class(self._limits, pixels, cval=0.)(y_, x_)
+
+        
+        x_pix_, y_pix_ = self.pixel_grid.map_coord2pix(x_pix.flatten(), y_pix.flatten())
+        x_pix_, y_pix_ = x_pix_.reshape(*x_pix.shape), y_pix_.reshape(*y_pix.shape)
+        x_pix_coords = x_pix_[0, :]
+        y_pix_coords = y_pix_[:, 0]
+        limits = [
+            ( y_pix_coords.min(), y_pix_coords.max() ), 
+            ( x_pix_coords.min(), x_pix_coords.max() )
+        ]
+
+
+        f = self._interp_class(limits, pixels, cval=0.)(y_, x_)
         return f / self._data_pixel_area
 
     def _function_std(self, x, y, pixels):

--- a/herculens/LightModel/light_model.py
+++ b/herculens/LightModel/light_model.py
@@ -1,6 +1,6 @@
 # High-level interface to a light model
 # 
-# Copyright (c) 2021, herculens developers and contributors
+# Copyright (c) 2023, herculens developers and contributors
 # Copyright (c) 2018, Simon Birrer & lenstronomy contributors
 # based on the LightModel module from lenstronomy (version 1.9.3)
 
@@ -31,17 +31,17 @@ class LightModel(LightModelBase):
     for a given set of parameters.
 
     """
-    def __init__(self, light_model_list, smoothing=0.001,
-                 pixel_interpol='bilinear', kwargs_pixelated=None, 
-                 shapelets_n_max=4, **kwargs):
+    def __init__(self, light_model_list, smoothing=0.001, shapelets_n_max=4,
+                 kwargs_pixelated=None, **kwargs):
         """Create a LightModel object."""
         self.profile_type_list = light_model_list
         super(LightModel, self).__init__(self.profile_type_list, smoothing=smoothing,
-                                         pixel_interpol=pixel_interpol, 
+                                         shapelets_n_max=shapelets_n_max,
                                          kwargs_pixelated=kwargs_pixelated,
-                                         shapelets_n_max=shapelets_n_max, **kwargs)
+                                         **kwargs)
 
-    def surface_brightness(self, x, y, kwargs_list, k=None):
+    def surface_brightness(self, x, y, kwargs_list, k=None,
+                           pixels_x_coord=None, pixels_y_coord=None):
         """Total source flux at a given position.
 
         Parameters
@@ -58,7 +58,13 @@ class LightModel(LightModelBase):
         bool_list = self._bool_list(k)
         for i, func in enumerate(self.func_list):
             if bool_list[i]:
-                flux += func.function(x, y, **kwargs_list[i])
+                if i == self.pixelated_index:
+                    flux += func.function(x, y, 
+                                          pixels_x_coord=pixels_x_coord, 
+                                          pixels_y_coord=pixels_y_coord, 
+                                          **kwargs_list[i])
+                else:
+                    flux += func.function(x, y, **kwargs_list[i])
         return flux
 
     def spatial_derivatives(self, x, y, kwargs_list, k=None):

--- a/herculens/RegulModel/regul_util.py
+++ b/herculens/RegulModel/regul_util.py
@@ -24,7 +24,7 @@ def data_noise_to_wavelet_light(lens_image, kwargs_res, model_type='source',
                                 wavelet_type_list=['starlet', 'battle-lemarie-3'],
                                 num_samples=1000, vmap_loop=True, sigma_clipping=True, seed=0,
                                 starlet_num_scales=None, starlet_second_gen=False, 
-                                noise_var=None, arc_mask=None):
+                                noise_var=None, arc_mask=None, median_per_scale=False):
     # get the data noise
     nx, ny = lens_image.Grid.num_pixel_axes
     if noise_var is None:
@@ -124,6 +124,11 @@ def data_noise_to_wavelet_light(lens_image, kwargs_res, model_type='source',
         # take the standard deviation
         std_per_scale = jnp.std(noise_samples_prop, axis=0)
 
+        if median_per_scale is True:
+            # single uniform value for each wavelet scale, we take the median value
+            medians = jnp.nanmedian(std_per_scale, axis=(-2, -1))
+            std_per_scale = np.full_like(std_per_scale, medians[:, np.newaxis, np.newaxis])
+            
         wavelet_class_list.append(wavelet)
         std_per_scale_list.append(std_per_scale)
 

--- a/herculens/RegulModel/regul_util.py
+++ b/herculens/RegulModel/regul_util.py
@@ -8,7 +8,8 @@ __author__ = 'aymgal'
 import copy
 import numpy as np
 import time
-from scipy import signal, stats
+from scipy import signal
+from scipy.interpolate import griddata
 import warnings
 
 import jax
@@ -20,11 +21,21 @@ from herculens.Util import vkl_util
 
 
 
+def interp_unstruct_grid(image, x, y, new_x, new_y):
+    interpolated_image = griddata((x.flatten(), y.flatten()), 
+                                  image.flatten(), 
+                                  (new_x.flatten(), new_y.flatten()), 
+                                  method='linear')
+    return interpolated_image.reshape(*new_x.shape)
+
+
+
 def data_noise_to_wavelet_light(lens_image, kwargs_res, model_type='source',
                                 wavelet_type_list=['starlet', 'battle-lemarie-3'],
                                 num_samples=1000, vmap_loop=True, sigma_clipping=True, seed=0,
                                 starlet_num_scales=None, starlet_second_gen=False, 
-                                noise_var=None, arc_mask=None, median_per_scale=False):
+                                noise_var=None, arc_mask=None, 
+                                median_per_scale=False, delensing_type='operator'):
     # get the data noise
     nx, ny = lens_image.Grid.num_pixel_axes
     if noise_var is None:
@@ -45,12 +56,25 @@ def data_noise_to_wavelet_light(lens_image, kwargs_res, model_type='source',
         raise ValueError("This function only supports (pixelated) 'source' or 'lens_light' profiles")
 
     if model_type == 'source':
-        # construct the lensing operator
-        lensing_op = lens_image.get_lensing_operator(
-            kwargs_lens=kwargs_res['kwargs_lens'], update=False, arc_mask=arc_mask,
-        )
-        def F_T(n): # de-lensing operation
-            return lensing_op.lensing_transpose(n)
+        if delensing_type == 'operator':
+            # construct the lensing operator
+            lensing_op = lens_image.get_lensing_operator(
+                kwargs_lens=kwargs_res['kwargs_lens'], update=False, arc_mask=arc_mask,
+            )
+            def F_T(n): # de-lensing operation
+                return lensing_op.lensing_transpose(n)
+            
+        elif delensing_type == 'interpol':
+            if vmap_loop is True:
+                raise NotImplementedError("Delensing operation via interpolation "
+                                          "is not yet compatible with JAX's vmap")
+            # TODO: update the following once it is possible to perform
+            # interpolation on unstructured grids using JAX
+            theta_x, theta_y = lens_image.Grid.pixel_coordinates 
+            beta_prime_x, beta_prime_y = lens_image.SourceModel.pixel_grid.pixel_coordinates
+            beta_x, beta_y = lens_image.MassModel.ray_shooting(theta_x, theta_y, kwargs_res['kwargs_lens'])
+            def F_T(n):
+                return interp_unstruct_grid(n, beta_x, beta_y, beta_prime_x, beta_prime_y)
 
     elif model_type == 'lens_light':
         def F_T(n): # identity operation
@@ -96,7 +120,6 @@ def data_noise_to_wavelet_light(lens_image, kwargs_res, model_type='source',
         def Phi_T(n): # wavelet transform
             return wavelet.decompose(n)
         
-        @jit
         def propagate_noise(n):
             # apply linear operators to propagate noise from image plane to source plane
             tmp = F_T(B_T(n))
@@ -114,7 +137,7 @@ def data_noise_to_wavelet_light(lens_image, kwargs_res, model_type='source',
 
         # propagate the noise to wavelet space for each of them
         if vmap_loop is True:
-            noise_samples_prop = vmap(propagate_noise)(noise_samples)
+            noise_samples_prop = vmap(jit(propagate_noise))(noise_samples)
         else:
             noise_samples_prop = []
             for noise in noise_samples:


### PR DESCRIPTION
Given an mask around encapsulating the lensed features (the 'arc_mask'), extent of the pixelated source plane is allowed to vary based on the deflection fields. This can be important mostly when constraining mass parameters that are feavily covariant on the size of the source (e.g., the logarithmic slope of the convergence profile).

Not that for wavelet regularization, in the current implementation, it would then be advised to use a uniform (median) regularization weight per wavelet scale, as the extent of the source plane is not fixed anymore. This PR also adds that option through the interface of `RegularizationModel.initialize()`.